### PR TITLE
Fix not replacing all "\" in paths

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -114,5 +114,5 @@ export async function writeDtsFiles(files: Record<string, string>) {
 
 export function getRelativePath(from: string, to: string) {
   const relativePath = path.relative(from, to);
-  return relativePath.replace("\\", "/");
+  return relativePath.replaceAll("\\", "/");
 }


### PR DESCRIPTION
When syncing scripts that are in sub-sub-folders or nested even deeper then only the first `\` is replaced. This PR proposes a change so that all `\` are replaced with `/`.